### PR TITLE
Run publish to testpypi only for PRs to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,11 @@
 ---
 
 name: Publish to PyPi
-on: push
+on:
+  push:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:
@@ -57,6 +61,7 @@ jobs:
 
   publish-to-testpypi:
     name: Publish Python distribution to TestPyPI
+    if: github.event_name == 'pull_request'
     needs:
     - build
     runs-on: ubuntu-latest


### PR DESCRIPTION
We want to test out that everything is ready for the release only
when ready to merge content to main branch.

Otherwise we are unlikley to have new minor version, thus upload will
be failing.

Signed-off-by: Dmitriy Rabotyagov <dmitriy@adria-cloud.com>